### PR TITLE
Remove lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "@mapstore/patcher",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapstore/patcher",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
         "jiff": "0.7.3",
-        "jsonpath": "1.1.1",
-        "lodash": "4.17.21"
+        "jsonpath": "1.1.1"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "7.8.3",
@@ -7264,7 +7263,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -15729,7 +15729,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "jiff": "0.7.3",
-    "jsonpath": "1.1.1",
-    "lodash": "4.17.21"
+    "jsonpath": "1.1.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.8.3",

--- a/src/Patcher.js
+++ b/src/Patcher.js
@@ -1,19 +1,15 @@
 import jiff from "jiff";
 import jp from "jsonpath";
-import isArray from "lodash/isArray";
-import isString from "lodash/isString";
-
-import castArray from "lodash/castArray";
 
 /**
  * convert paths from jsonpath format to json patch format
  * @param {object[]} paths array of paths in jsonpath format
  */
 export const transformPath = (paths) => {
-  if (isArray(paths)) {
+  if (Array.isArray(paths)) {
     return paths.map(([, ...other]) => ["", ...other].join("/"));
   }
-  return isString(paths) ? paths : "";
+  return typeof paths === "string" ? paths : "";
 };
 
 /**
@@ -32,7 +28,11 @@ export const transformPath = (paths) => {
  * {op: "replace", jsonpath: "$.plugins..[?(@.name == 'ZoomIn')].cfg.maxZoom, value: 3}
  */
 export const convertToJsonPatch = (sourceJSON = {}, rawRules = []) => {
-  const patchRules = castArray(rawRules).reduce(
+  if (!Array.isArray(rawRules)) {
+    rawRules = [rawRules];
+  }
+
+  const patchRules = rawRules.reduce(
     (p, { op, jsonpath, path: jsonpatch, value }) => {
       let transformedPaths;
       if (jsonpatch) {

--- a/src/Patcher.test.js
+++ b/src/Patcher.test.js
@@ -1,5 +1,4 @@
 import expect from "expect";
-import find from "lodash/find";
 
 import {
   transformPath,
@@ -284,17 +283,17 @@ describe("Patch Utils", () => {
         const config = mergeConfigsPatch(full, plugins03);
         expect(config).toBeTruthy();
         expect(
-          find(config.plugins.mobile, ({ name }) => name === "Search").cfg
+          config.plugins.mobile.find(({ name }) => name === "Search").cfg
             .searchOptions.services[0].options.replacedEverywhereSecondRule
         ).toBeTruthy();
 
         expect(
-          find(config.plugins.desktop, ({ name }) => name === "Search").cfg
+          config.plugins.desktop.find(({ name }) => name === "Search").cfg
             .searchOptions.services[0].options.replacedEverywhereSecondRule
         ).toBeTruthy();
 
         expect(
-          find(config.plugins.embedded, ({ name }) => name === "Search").cfg
+          config.plugins.embedded.find(({ name }) => name === "Search").cfg
             .searchOptions.services[0].options.replacedEverywhereSecondRule
         ).toBeTruthy();
       } catch (e) {
@@ -315,15 +314,8 @@ describe("Patch Utils", () => {
         expect(config).toBeTruthy();
         expect(config.mailingList).toBeFalsy();
         expect(config.proxyUrl.useCORS.length).toBe(4);
-        expect(
-          find(config.plugins.desktop, ({ name }) => name === "LayerInfo")
-        ).toBeTruthy();
-        expect(
-          find(
-            config.plugins.desktop,
-            ({ name }) => name === "IdentifySettings"
-          )
-        ).toBeTruthy();
+        expect(config.plugins.desktop.find(({ name }) => name === "LayerInfo")).toBeTruthy();
+        expect(config.plugins.desktop.find(({ name }) => name === "IdentifySettings")).toBeTruthy();
       } catch (e) {
         expect(e).toBe(false);
       }


### PR DESCRIPTION
This PR removes lodash from the list of dependencies.
I replaced the functionality ( isArray, find, castArray ) with native javascript, and updated the test.
I think it is safe remove lodash, because the functions that we use are all available in modern browsers.

The reason for this PR is because I ran into a issue in a mapstore project, where I was writing test using Vitest, and it had problems resolving lodash/isArray.